### PR TITLE
Added ability to menu to copy current location to the clipboard.

### DIFF
--- a/res/menu/main.xml
+++ b/res/menu/main.xml
@@ -9,7 +9,9 @@
         android:showAsAction="never"
         android:title="@string/action_settings"/>
     <item android:id="@+id/action_legend" android:title="@string/action_legend"></item>
+    <item android:id="@+id/action_copy_location" android:title="@string/action_copy_location"></item>
     <item android:id="@+id/action_about" android:title="@string/action_about"></item>
     
 
 </menu>
+

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="action_stop_record">Stop recording</string>
     <string name="action_agps">Reload AGPS data</string>
     <string name="action_legend">Legend</string>
+    <string name="action_copy_location">Copy Location</string>
     <string name="action_about">About</string>
     <string name="dot" translatable="false">&#x25a0;</string>
     <string name="smallDot" translatable="false">&#x25fc;</string>

--- a/src/com/vonglasow/michael/satstat/ui/GpsSectionFragment.java
+++ b/src/com/vonglasow/michael/satstat/ui/GpsSectionFragment.java
@@ -67,11 +67,11 @@ public class GpsSectionFragment extends Fragment {
 	private GpsStatusView gpsStatusView;
 	private GpsSnrView gpsSnrView;
 	private LinearLayout gpsLatLayout;
-	private TextView gpsLat;
+	static TextView gpsLat; // Static for copy to clipboard
 	private LinearLayout gpsLonLayout;
-	private TextView gpsLon;
+	static TextView gpsLon; // Static for copy to clipboard
 	private LinearLayout gpsCoordLayout;
-	private TextView gpsCoord;
+	static TextView gpsCoord; // Static for copy to clipboard
 	private TextView orDeclination;
 	private TextView gpsSpeed;
 	private TextView gpsSpeedUnit;

--- a/src/com/vonglasow/michael/satstat/ui/MainActivity.java
+++ b/src/com/vonglasow/michael/satstat/ui/MainActivity.java
@@ -42,6 +42,8 @@ import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -84,6 +86,10 @@ import static android.telephony.PhoneStateListener.LISTEN_CELL_LOCATION;
 import static android.telephony.PhoneStateListener.LISTEN_DATA_CONNECTION_STATE;
 import static android.telephony.PhoneStateListener.LISTEN_NONE;
 import static android.telephony.PhoneStateListener.LISTEN_SIGNAL_STRENGTHS;
+import static com.vonglasow.michael.satstat.ui.GpsSectionFragment.gpsCoord;
+import static com.vonglasow.michael.satstat.ui.GpsSectionFragment.gpsLat;
+import static com.vonglasow.michael.satstat.ui.GpsSectionFragment.gpsLon;
+
 import android.telephony.SignalStrength;
 import android.telephony.TelephonyManager;
 import android.util.Log;
@@ -148,6 +154,8 @@ public class MainActivity extends AppCompatActivity implements GpsStatus.Listene
 	WifiManager wifiManager;
 	LocationManager locationManager;
 	SensorManager sensorManager;
+
+	ClipboardManager clipboard; // Add ability to copy location to the clipboard.
 	
 	boolean[] permsRequested = new boolean[Const.PERM_REQUEST_MAX + 1];
 
@@ -199,6 +207,7 @@ public class MainActivity extends AppCompatActivity implements GpsStatus.Listene
 	boolean prefCid2 = false;
 	int prefWifiSort = 0;
 	boolean prefMapOffline = false;
+	String clipLocation;
 	String prefMapPath = Const.MAP_PATH_DEFAULT;
 
 	/** 
@@ -306,6 +315,8 @@ public class MainActivity extends AppCompatActivity implements GpsStatus.Listene
 	@Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+		clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
         
         defaultUEH = Thread.getDefaultUncaughtExceptionHandler();
         
@@ -497,6 +508,22 @@ public class MainActivity extends AppCompatActivity implements GpsStatus.Listene
 			return true;
 		} else if (itemId == R.id.action_legend) {
 			startActivity(new Intent(this, LegendActivity.class));
+			return true;
+		} else if (itemId == R.id.action_copy_location) {
+			/* 
+			 * Copy the currently displayed location to the clipboard.
+			 * Use visible location textviews as this is set by the user
+			 * for decimal, minute, second, mgrs.
+			 */
+			if (prefCoord == Const.KEY_PREF_COORD_MGRS) {
+				clipLocation = gpsCoord.getText().toString();
+			} else {
+				clipLocation = gpsLat.getText().toString() + " " + gpsLon.getText().toString();
+			}
+			ClipData clip = ClipData.newPlainText("Location ", clipLocation);
+			clipboard.setPrimaryClip(clip);
+			Toast.makeText(getApplicationContext(), clipLocation +
+					" copied to the clipboard.", Toast.LENGTH_SHORT).show();
 			return true;
 		} else if (itemId == R.id.action_about) {
 			startActivity(new Intent(this, AboutActivity.class));
@@ -926,3 +953,4 @@ public class MainActivity extends AppCompatActivity implements GpsStatus.Listene
         }
     }
 }
+


### PR DESCRIPTION
In reference to issue #95 I have added the ability to copy the current location to your clipboard, which can be pasted into any other application.

A few notes:
I used the text views to pull the data for the clipboard because if you do not have a position, then you will get - - instead of an error or nothing. And it will copy the location in the method specified in settings menu. If you choose MGRS, Decimal, Dec min, DDMMSS, it still copies as you set in your settings preferences.

I have tested this on a Samsung Galaxy S4, Android 7.1.2, using MGRS, Decimal, Decimal Minutes, and Decimal Minutes Seconds. All copied without error. I also tested if you have no location, still copies to clipboard without error, just as " - - ".