### PR TITLE
Remove extra 0 from sensor refresh rate

### DIFF
--- a/src/com/vonglasow/michael/satstat/ui/MainActivity.java
+++ b/src/com/vonglasow/michael/satstat/ui/MainActivity.java
@@ -136,7 +136,7 @@ public class MainActivity extends AppCompatActivity implements GpsStatus.Listene
     
 	//The rate in microseconds at which we would like to receive updates from the sensors.
 	//private static final int iSensorRate = SensorManager.SENSOR_DELAY_UI;
-	private static final int iSensorRate = 200000; //Default is 20,000 for accel, 5,000 for gyro
+	private static final int iSensorRate = 20000; //Default is 20,000 for accel, 5,000 for gyro
 
 	GpsSectionFragment gpsSectionFragment = null;
 	SensorSectionFragment sensorSectionFragment = null;


### PR DESCRIPTION
When running an on LG G5 w/ Android 7.0 (stock), the sensor refresh rate seems very low (see https://github.com/mvglasow/satstat/issues/122#issuecomment-331667328).

Here's the current master branch at https://github.com/mvglasow/satstat/commit/5f10dd41f5543ecb826cc54e697cbc0d83588216, which is around 3fps:
https://www.dropbox.com/s/cvn6gxoxlwgu0qc/satstat-LG-G5-TYPE_ORIENTATION.mp4?dl=0

Looking at the comments, it appears there is an extra 0 in the refresh rate.  This patch removes the extra 0.

Here's this patch on same device, running at ~26fps:
https://www.dropbox.com/s/vobdf7o7mr8yof9/satstat-LG-G5-TYPE_ORIENTATION-20000.mp4?dl=0