### PR TITLE
Bump build tools, remove exact Java dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
@@ -12,16 +12,11 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.3'
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 11
         targetSdkVersion 23
-    }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
     }
 
     packagingOptions {


### PR DESCRIPTION
* This updates `build.gradle` to run from a fresh clone using Android Studio 2.3.3
* The `compileOptions` Java versions prevent the project from building on a machine that has only Java 8 installed.  By removing the explicit version of Java it should build on any machine (with a compatible Java version for Android Studio or Gradle.