### PR TITLE
Fix issue computing DMS Seconds value.

### DIFF
--- a/src/com/vonglasow/michael/satstat/ui/GpsSectionFragment.java
+++ b/src/com/vonglasow/michael/satstat/ui/GpsSectionFragment.java
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2013–2016 Michael von Glasow.
- * 
+ *
  * This file is part of LSRN Tools.
  *
  * LSRN Tools is free software: you can redistribute it and/or modify
@@ -202,17 +202,19 @@ public class GpsSectionFragment extends Fragment {
 			gpsCoordLayout.setVisibility(View.GONE);
 			gpsLatLayout.setVisibility(View.VISIBLE);
 			gpsLonLayout.setVisibility(View.VISIBLE);
+
 			double dec = location.getLatitude();
 			double deg = (int) dec;
-			double tmp = 60.0 * (dec - deg);
-			double min = (int) Math.abs(tmp);
-			double sec = Math.abs(60.0 * (tmp - min));
+			double tmp = Math.abs(60.0 * (dec - deg));
+			double min = (int) tmp;
+			double sec = 60.0 * (tmp - min);
 			gpsLat.setText(String.format("%.0f%s %.0f' %.1f\"", deg, getString(R.string.unit_degree), min, sec + /*rounding*/ 0.05));
+
 			dec = location.getLongitude();
 			deg = (int) dec;
-			tmp = 60.0 * (dec - deg);
-			min = (int) Math.abs(tmp);
-			sec = Math.abs(60.0 * (tmp - min));
+			tmp = Math.abs(60.0 * (dec - deg));
+			min = (int) tmp;
+			sec = 60.0 * (tmp - min);
 			gpsLon.setText(String.format("%.0f%s %.0f' %.1f\"", deg, getString(R.string.unit_degree), min, sec + /*rounding*/ 0.05));
 		} else if (mainActivity.prefCoord == Const.KEY_PREF_COORD_MGRS) {
 			gpsLatLayout.setVisibility(View.GONE);
@@ -285,7 +287,7 @@ public class GpsSectionFragment extends Fragment {
 	/**
 	 * Called by {@link MainActivity} when a sensor's reading changes.
 	 * Rotates sky plot according to bearing.
-	 * 
+	 *
 	 * If {@code TYPE_ORIENTATION} data is available, preference is given to that value, which
 	 * appeared to be more accurate in tests. Otherwise orientation is obtained from the rotation
 	 * vector of the device, based on {@link TYPE_ACCELEROMETER} and {@code TYPE_MAGNETIC_FIELD}


### PR DESCRIPTION
The abs call on minutes causes the subtractions for second to move further from 0, not closer.

    dec = -122.084
    deg = -122

## current

    tmp = 60.0 * (dec - deg);

tmp = -5.04

    min = (int) Math.abs(tmp);

min = 5

    sec = Math.abs(60.0 * (tmp - min));

sec = abs(60 * (-5.04 - 5)) = abs(60*-10.04) = -602.4

-----

## pr

    tmp = Math.abs(60.0 * (dec - deg));

tmp = 5.04

    min = (int) tmp;

min = 5

    sec = 60.0 * (tmp - min);

sec = 60 * (5.04 - 5) = 60 * 0.04 = 2.4

------

This appears to work and fix the issue. Tested in in Android Studio.


![screenshot_1542955416](https://user-images.githubusercontent.com/40850/48930902-6b3c1a80-eec1-11e8-93c1-4f09a6a51bfb.png)
![screenshot_1542955323](https://user-images.githubusercontent.com/40850/48930903-6b3c1a80-eec1-11e8-897a-63f85a72a583.png)
![screenshot_1542955310](https://user-images.githubusercontent.com/40850/48930904-6b3c1a80-eec1-11e8-843b-3139b1898d85.png)
